### PR TITLE
Not having the IP address package installed is no longer a blocker

### DIFF
--- a/device_api-ios.gemspec
+++ b/device_api-ios.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-ios'
-  s.version     = '1.0.5'
+  s.version     = '1.0.6'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'IOS Device Management API'
   s.description = 'iOS implementation of DeviceAPI'

--- a/lib/device_api/ios/ipaddress.rb
+++ b/lib/device_api/ios/ipaddress.rb
@@ -20,7 +20,7 @@ module DeviceAPI
         if DeviceAPI::IOS::IDeviceInstaller.package_installed?( serial: serial, package: ipaddress_bundle_id )
           return true
         else
-          raise IPAddressError.new('IP Address package not installed: Please see https://github.com/bbc/ios-test-helper')
+          warn IPAddressError.new('IP Address package not installed: Please see https://github.com/bbc/ios-test-helper')
         end
       end
 
@@ -28,7 +28,7 @@ module DeviceAPI
       # @param [String] serial serial of the target device
       # @return [String] IP Address if found
       def self.address(serial)
-        installed?(serial)
+        return nil unless installed?(serial)
         result = IDeviceDebug.run(serial: serial, bundle_id: ipaddress_bundle_id )
 
         ip_address = nil


### PR DESCRIPTION
Fixes bbc/hive-runner-ios#26